### PR TITLE
Add jspecify @Nullable annotation as lombok copyable annotations

### DIFF
--- a/nullaway-lombok/lombok.config
+++ b/nullaway-lombok/lombok.config
@@ -1,2 +1,3 @@
 config.stopBubbling = true
 lombok.addLombokGeneratedAnnotation = true
+lombok.copyableAnnotations+=org.jspecify.annotations.Nullable


### PR DESCRIPTION
Relates to https://github.com/uber/NullAway/issues/917#issuecomment-1950249370

Set `org.jspecify.annotations.Nullable` annotation as copyable annotation in lombok so that jspecify annotations are recognized by NullAway.